### PR TITLE
fix(AR-17): fix animation speed overriding and disabled state in ShinyText

### DIFF
--- a/src/components/ShinyText/ShinyText.tsx
+++ b/src/components/ShinyText/ShinyText.tsx
@@ -30,8 +30,7 @@ const ShinyText = ({
             'linear-gradient(120deg, rgba(255, 255, 255, 0) 40%, rgba(255, 255, 255, 1) 50%, rgba(255, 255, 255, 0) 60%)',
           backgroundSize: '200% 100%',
           WebkitBackgroundClip: 'text',
-          animationDuration: animationDuration,
-          animation: 'shine 5s linear infinite',
+          animation: disabled ? 'none' : `shine ${animationDuration} linear infinite`,
         }}
       >
         {text}

--- a/src/components/ShinyText/__tests__/ShinyText.test.tsx
+++ b/src/components/ShinyText/__tests__/ShinyText.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ShinyText from '../ShinyText';
+
+describe('ShinyText', () => {
+  it('should render the ShinyText component with correct text', () => {
+    const { container } = render(<ShinyText text="Hello World" />);
+    expect(screen.getByText('Hello World')).toBeInTheDocument();
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should apply correct animation style using default speed prop', () => {
+    render(<ShinyText text="Dynamic Speed Default" />);
+    const element = screen.getByText('Dynamic Speed Default');
+    expect(element).toHaveStyle({
+      animation: 'shine 5s linear infinite',
+    });
+  });
+
+  it('should apply correct animation style using custom speed prop', () => {
+    render(<ShinyText text="Dynamic Speed Custom" speed={10} />);
+    const element = screen.getByText('Dynamic Speed Custom');
+    expect(element).toHaveStyle({
+      animation: 'shine 10s linear infinite',
+    });
+  });
+
+  it('should disable animation when disabled is true', () => {
+    const { container } = render(<ShinyText text="Disabled Animation" disabled={true} />);
+    const element = screen.getByText('Disabled Animation');
+    expect(element).toHaveStyle({
+      animation: 'none',
+    });
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should pass custom className to the element', () => {
+    render(<ShinyText text="Class Test" className="custom-class" />);
+    const element = screen.getByText('Class Test');
+    expect(element).toHaveClass('custom-class');
+  });
+});

--- a/src/components/ShinyText/__tests__/__snapshots__/ShinyText.test.tsx.snap
+++ b/src/components/ShinyText/__tests__/__snapshots__/ShinyText.test.tsx.snap
@@ -1,0 +1,43 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ShinyText should disable animation when disabled is true 1`] = `
+<div>
+  <style>
+    @keyframes shine {
+            0% {
+                background-position: 100%;
+                }
+            100% {
+                background-position: -100%;
+                }
+            }
+  </style>
+  <div
+    class="text-[#b5b5b5a4] bg-clip-text inline-block  "
+    style="background-size: 200% 100%; animation: none;"
+  >
+    Disabled Animation
+  </div>
+</div>
+`;
+
+exports[`ShinyText should render the ShinyText component with correct text 1`] = `
+<div>
+  <style>
+    @keyframes shine {
+            0% {
+                background-position: 100%;
+                }
+            100% {
+                background-position: -100%;
+                }
+            }
+  </style>
+  <div
+    class="text-[#b5b5b5a4] bg-clip-text inline-block animate-shine "
+    style="background-size: 200% 100%; animation: shine 5s linear infinite;"
+  >
+    Hello World
+  </div>
+</div>
+`;


### PR DESCRIPTION
## Issue:

- The `ShinyText` component ignored the custom `speed` prop due to a hardcoded animation duration of 5s in its style properties. Additionally, the animation remained active even when the component was configured with `disabled={true}`.

## Rootcause:

- The inline `style` attribute applied `animation: 'shine 5s linear infinite'` which completely overrode the computed `animationDuration` value. Also, there was no conditional logic on `animation` to check if `disabled` is true.

## Fix

- Modified the inline `style` to dynamically set `animation: disabled ? 'none' : \`shine \${animationDuration} linear infinite\``.

### Implementation

- Update ShinyText style property to dynamically configure the animation using `animationDuration` and the `disabled` state.
- Implement comprehensive unit tests at `src/components/ShinyText/__tests__/ShinyText.test.tsx` to assert on text rendering, custom speed, disabled state, and snapshot matching.

Ticket: https://ar1603.atlassian.net/browse/AR-17
Author: Amit Raikwar