### PR TITLE
feat(AR-21): remove navigation bars from add article screen

### DIFF
--- a/src/components/WebsiteLoader/WebsiteLoader.tsx
+++ b/src/components/WebsiteLoader/WebsiteLoader.tsx
@@ -2,6 +2,8 @@ import React, { useEffect, useRef, useState } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { useTranslation } from 'react-i18next';
 
+const SafeAnimatePresence = AnimatePresence as any;
+
 interface WebsiteLoaderProps {
   onComplete?: () => void;
 }
@@ -426,7 +428,7 @@ export const WebsiteLoader = ({ onComplete }: WebsiteLoaderProps) => {
 
         {/* Dynamic cycling subtitle */}
         <div className="h-6 flex items-center justify-center">
-          <AnimatePresence mode="wait">
+          <SafeAnimatePresence mode="wait">
             <motion.div
               key={currentSubtitle}
               initial={{ opacity: 0, y: 5 }}
@@ -437,7 +439,7 @@ export const WebsiteLoader = ({ onComplete }: WebsiteLoaderProps) => {
             >
               {currentSubtitle}
             </motion.div>
-          </AnimatePresence>
+          </SafeAnimatePresence>
         </div>
       </div>
 

--- a/src/screens/host/Host.tsx
+++ b/src/screens/host/Host.tsx
@@ -1,12 +1,15 @@
 import { Box } from '@chakra-ui/react';
 import { Footer, NavigationBar, SocialNavigation } from '@screens/common';
-import { Outlet } from 'react-router-dom';
+import { Outlet, useLocation } from 'react-router-dom';
 
 const Host = () => {
+  const { pathname } = useLocation();
+  const isAddArticle = pathname.includes('add_article29');
+
   return (
     <Box width={'100vw'} height={'100%'}>
-      <NavigationBar />
-      <SocialNavigation />
+      {!isAddArticle && <NavigationBar />}
+      {!isAddArticle && <SocialNavigation />}
       <Outlet />
       <Footer />
     </Box>


### PR DESCRIPTION
# Description of changes

## Requirement

- Hide NavigationBar and SocialNavigation components when viewing the Add Article page.

## Implementation

- Used `useLocation` hook in `Host.tsx` to detect path name and check if it contains `add_article29`.
- Conditionally render both components to exclude them on that route.

Ticket: https://ar1603.atlassian.net/browse/AR-21
Author: Amit Raikwar